### PR TITLE
bug-fix: translate internal units for distance and speed into FIT units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet!
+### Fixed
+
+* fix: properly translate the `BikeData` internal units to the FIT file units
 
 ## [0.3.0]
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -83,7 +83,8 @@ fn to_message(data: &BikeData) -> Message {
         rec.power = power;
     }
     if let Some(speed) = data.speed {
-        rec.speed = speed;
+        // Translate from 10m/hour (our internal unit) => mm/second (the FIT unit)
+        rec.speed = (speed as f32 * 2.777) as u16;
     }
     if let Some(heart_rate) = data.heart_rate {
         rec.heart_rate = heart_rate;
@@ -92,7 +93,8 @@ fn to_message(data: &BikeData) -> Message {
         rec.resistance = resistance;
     }
     if let Some(distance) = data.distance {
-        rec.distance = distance;
+        // Translate from meters (our internal unit) => centimeters (the FIT unit)
+        rec.distance = distance * 100;
     }
 
     rec.timestamp = to_fit_datetime(data.time);

--- a/src/record.rs
+++ b/src/record.rs
@@ -41,7 +41,10 @@ fn to_fit(data: &mut [BikeData]) -> FIT {
 
     // NOTE: required messages and fields via
     // https://developer.garmin.com/fit/file-types/activity/
-    let total_dist: u32 = data.iter().map(|bd| bd.distance.unwrap_or_default()).sum();
+    let total_dist: u32 = data
+        .iter()
+        .map(|bd| bd.distance.unwrap_or_default() * 100)
+        .sum();
     let mut messages: Vec<Message> = data.iter().map(to_message).collect();
     messages.insert(0, Message::from(get_file_id(start)));
     messages.push(Message::from(get_activity(start)));

--- a/src/trainer.rs
+++ b/src/trainer.rs
@@ -252,7 +252,7 @@ mod tests {
             }
 
             if field.num == mesgdef::Record::SPEED {
-                assert_eq!(field.value.as_u16(), 20)
+                assert_eq!(field.value.as_u16(), 55)
             }
 
             if field.num == mesgdef::Record::HEART_RATE {
@@ -281,7 +281,7 @@ mod tests {
             }
 
             if field.num == mesgdef::Record::SPEED {
-                assert_eq!(field.value.as_u16(), 20)
+                assert_eq!(field.value.as_u16(), 55)
             }
 
             if field.num == mesgdef::Record::HEART_RATE {


### PR DESCRIPTION
distance is held as *meters* internally and as *centimeters* for FIT
speed is held as 10m/hour internally and as mm/s for FIT

Closes: #51