### PR TITLE
bugfix: distance calculation error via integer truncation

### DIFF
--- a/src/trainer.rs
+++ b/src/trainer.rs
@@ -77,7 +77,7 @@ impl<T: FitnessDevice + std::fmt::Debug> Trainer<T> {
                 {
                     let last = self.data[self.data.len() - 1];
                     let dt = (data.time - last.time).as_seconds_f32();
-                    let dist = (dt * (speed / 360) as f32) as u32;
+                    let dist = (dt * speed as f32 / 360.0) as u32;
                     data.distance = Some(dist);
                 }
                 self.data.push_back(data);


### PR DESCRIPTION
BikeData.speed is a u16 in units of 10m/hour, so it appears you are converting into meters/second, then rectangular integrating over time dt seconds.  By performing integer division before f32 multiplication, the fractional part of speed/360 is truncated and this results in a rounding error.